### PR TITLE
Change link to .NET article and update to 3.2.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
                 <a href="http://pcsupport.about.com/od/windows-8/a/windows-8-64-bit-32-bit.htm">
                     grein hér fyrir Windows 8+</a>.</li>
             <li><a name="2"></a>Til að komast að því hvort tölvan sé með .NET 3.5 eða .NET 4.0+, sjá
-                <a href="http://support.microsoft.com/kb/318785">grein hér</a>.</li>
+                <a href="http://www.apesoftware.com/articles/check-for-dotnet.aspx">grein hér</a>.</li>
             <li><a name="3"></a><a href="http://wiki.zimbra.com/wiki/Zimlets,_Setting_Up">Uppsetningarleiðbeiningar fyrir Zimbra
                 Zimlet</a></li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     </div>
     <div id="pgcontent">
         <div class="pgdngroup">
-            <h2>CoreData Desktop <span id="cdd_version">3.0.1</span></h2>
+            <h2>CoreData Desktop <span id="cdd_version">3.2.0</span></h2>
 
             <p>CoreData Desktop er fáanlegt fyrir Windows stýrikerfi. Mismunandi útgáfur eru til fyrir 64 bita
                 örgjörva annars vegar og hins vegar x86<sup>(<a href="#1">1</a>)</sup>. Einnig skiptir máli hvort .NET 4.0 eða nýrra


### PR DESCRIPTION
Contains:
- Change .NET help link - Suggested change by @oskarthr
- Bump CoreData Desktop base version to 3.2.0 which is soon to be released 
